### PR TITLE
Fix compile error

### DIFF
--- a/Ninja Price/API/PoeNinja/API.cs
+++ b/Ninja Price/API/PoeNinja/API.cs
@@ -41,7 +41,7 @@ namespace Ninja_Price.API.PoeNinja
 
             public static TSettingType LoadSettingFile<TSettingType>(string fileName)
             {
-                return !File.Exists(fileName) ? default : JsonConvert.DeserializeObject<TSettingType>(File.ReadAllText(fileName));
+                return JsonConvert.DeserializeObject<TSettingType>(File.ReadAllText(fileName));
             }
 
             public static bool SaveSettingFile<TSettingType>(string fileName, TSettingType setting)


### PR DESCRIPTION
POEHud was complaining about this and wouldn't compile the plugin:
Feature 'default literal' is not available in C# 7.0. Please use language version 7.1 or greater.
Couldn't really find a solution to that, so removed the default literal. It's for loading settings file, so I guess now it would just return an error instead of false.
Now the plugin works. As far as I can tell.